### PR TITLE
Release 2.1 Changing the mechanism for saving and deleting Refresh Token

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -381,54 +381,56 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "3.8.0",
+            "version": "3.9.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "d09ea80159c1929d75b3f9c60504d613aeb4a1e3"
+                "reference": "dc75aa439eb4c1b77f5379fd958b3dc0e6014178"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/d09ea80159c1929d75b3f9c60504d613aeb4a1e3",
-                "reference": "d09ea80159c1929d75b3f9c60504d613aeb4a1e3",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/dc75aa439eb4c1b77f5379fd958b3dc0e6014178",
+                "reference": "dc75aa439eb4c1b77f5379fd958b3dc0e6014178",
                 "shasum": ""
             },
             "require": {
-                "paragonie/random_compat": "^1.0|^2.0|9.99.99",
-                "php": "^5.4 || ^7.0",
+                "ext-json": "*",
+                "paragonie/random_compat": "^1 | ^2 | ^9.99.99",
+                "php": "^5.4 | ^7.0 | ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "replace": {
                 "rhumsaa/uuid": "self.version"
             },
             "require-dev": {
-                "codeception/aspect-mock": "^1.0 | ~2.0.0",
-                "doctrine/annotations": "~1.2.0",
-                "goaop/framework": "1.0.0-alpha.2 | ^1.0 | ~2.1.0",
-                "ircmaxell/random-lib": "^1.1",
-                "jakub-onderka/php-parallel-lint": "^0.9.0",
-                "mockery/mockery": "^0.9.9",
+                "codeception/aspect-mock": "^1 | ^2",
+                "doctrine/annotations": "^1.2",
+                "goaop/framework": "1.0.0-alpha.2 | ^1 | >=2.1.0 <=2.3.2",
+                "mockery/mockery": "^0.9.11 | ^1",
                 "moontoast/math": "^1.1",
-                "php-mock/php-mock-phpunit": "^0.3|^1.1",
-                "phpunit/phpunit": "^4.7|^5.0|^6.5",
-                "squizlabs/php_codesniffer": "^2.3"
+                "nikic/php-parser": "<=4.5.0",
+                "paragonie/random-lib": "^2",
+                "php-mock/php-mock-phpunit": "^0.3 | ^1.1 | ^2.6",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpunit/phpunit": ">=4.8.36 <9.0.0 | >=9.3.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "suggest": {
                 "ext-ctype": "Provides support for PHP Ctype functions",
                 "ext-libsodium": "Provides the PECL libsodium extension for use with the SodiumRandomGenerator",
+                "ext-openssl": "Provides the OpenSSL extension for use with the OpenSslGenerator",
                 "ext-uuid": "Provides the PECL UUID extension for use with the PeclUuidTimeGenerator and PeclUuidRandomGenerator",
-                "ircmaxell/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
                 "moontoast/math": "Provides support for converting UUID to 128-bit integer (in string form).",
+                "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
                 "ramsey/uuid-console": "A console application for generating UUIDs with ramsey/uuid",
                 "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
                 "psr-4": {
                     "Ramsey\\Uuid\\": "src/"
                 }
@@ -439,17 +441,17 @@
             ],
             "authors": [
                 {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                },
+                {
                     "name": "Marijn Huizendveld",
                     "email": "marijn.huizendveld@gmail.com"
                 },
                 {
                     "name": "Thibaud Fabre",
                     "email": "thibaud@aztech.io"
-                },
-                {
-                    "name": "Ben Ramsey",
-                    "email": "ben@benramsey.com",
-                    "homepage": "https://benramsey.com"
                 }
             ],
             "description": "Formerly rhumsaa/uuid. A PHP 5.4+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
@@ -459,7 +461,23 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2018-07-19T23:38:55+00:00"
+            "support": {
+                "issues": "https://github.com/ramsey/uuid/issues",
+                "rss": "https://github.com/ramsey/uuid/releases.atom",
+                "source": "https://github.com/ramsey/uuid",
+                "wiki": "https://github.com/ramsey/uuid/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ramsey",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ramsey/uuid",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-19T21:55:10+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/src/Repository/RefreshTokenValue.php
+++ b/src/Repository/RefreshTokenValue.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wearesho\Yii2\Authorization\Repository;
+
+class RefreshTokenValue
+{
+
+    private string $accessToken;
+    private int $userId;
+
+    public function __construct(string $accessToken, int $userId)
+    {
+        $this->accessToken = $accessToken;
+        $this->userId = $userId;
+    }
+
+    public function getAccessToken(): string
+    {
+        return $this->accessToken;
+    }
+
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+}

--- a/src/Repository/RefreshTokenValue.php
+++ b/src/Repository/RefreshTokenValue.php
@@ -6,7 +6,6 @@ namespace Wearesho\Yii2\Authorization\Repository;
 
 class RefreshTokenValue
 {
-
     private string $accessToken;
     private int $userId;
 

--- a/src/Repository/RefreshTokenValueEncoder.php
+++ b/src/Repository/RefreshTokenValueEncoder.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wearesho\Yii2\Authorization\Repository;
+
+class RefreshTokenValueEncoder
+{
+    public const VALUE_PREFIX = 'v2';
+    public const VALUE_SEPARATOR = ':';
+    public const VALUE_HASH_ALGO = 'fnv1a32';
+
+    public function encode(RefreshTokenValue $value): string
+    {
+        $values = [
+            static::VALUE_PREFIX,
+            $value->getAccessToken(),
+            $value->getUserId(),
+            $this->getHash($value),
+        ];
+        return implode(static::VALUE_SEPARATOR, $values);
+    }
+
+    public function decode(string $value): ?RefreshTokenValue
+    {
+        $values = explode(static::VALUE_SEPARATOR, $value, 4);
+        if (count($values) !== 4) {
+            return null;
+        }
+        [$prefix, $accessToken, $userId, $hash] = $values;
+        if ($prefix !== static::VALUE_PREFIX) {
+            return null;
+        }
+        $value = new RefreshTokenValue($accessToken, (int)$userId);
+        $validHash = $this->getHash($value);
+        if ($validHash !== $hash) {
+            return null;
+        }
+        return $value;
+    }
+
+    private function getHash(RefreshTokenValue $value): string
+    {
+        return hash(
+            static::VALUE_HASH_ALGO,
+            implode(static::VALUE_SEPARATOR, [
+                strrev($value->getAccessToken()),
+                static::VALUE_PREFIX,
+                strrev((string)$value->getUserId())
+            ])
+        );
+    }
+}
+

--- a/src/Repository/RefreshTokenValueEncoder.php
+++ b/src/Repository/RefreshTokenValueEncoder.php
@@ -51,4 +51,3 @@ class RefreshTokenValueEncoder
         );
     }
 }
-

--- a/tests/Repository/RefreshTokenValueEncoderTest.php
+++ b/tests/Repository/RefreshTokenValueEncoderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wearesho\Yii2\Authorization\Tests\Repository;
+
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use Wearesho\Yii2\Authorization\Repository\RefreshTokenValue;
+use Wearesho\Yii2\Authorization\Repository\RefreshTokenValueEncoder;
+
+class RefreshTokenValueEncoderTest extends TestCase
+{
+    public function decodingDataProvider(): iterable
+    {
+        return [
+            [Uuid::uuid4()->toString(), null], // deprecated values
+            ['not-really-valid-data', null],
+            ['v2:eeea00b7-d766-4570-864c-a9fd5c288489:1337:invalid-hash', null,],
+            ['v2:eeea00b7-d766-4570-864c-a9fd5c288489:1337:8b9746bf', new RefreshTokenValue(
+                'eeea00b7-d766-4570-864c-a9fd5c288489',
+                1337,
+            )],
+        ];
+    }
+
+    /**
+     * @dataProvider decodingDataProvider
+     */
+    public function testDecoding(string $encodedValue, ?RefreshTokenValue $expectedValue): void
+    {
+        $encoder = new RefreshTokenValueEncoder();
+        $value = $encoder->decode($encodedValue);
+        $this->assertEquals($expectedValue, $value);
+    }
+
+    public function testEncodeAndDecode()
+    {
+        $accessToken = 'sampleAccessToken';
+        $userId = 123;
+
+        $value = new RefreshTokenValue($accessToken, $userId);
+        $encoder = new RefreshTokenValueEncoder();
+
+        $encodedValue = $encoder->encode($value);
+        $decodedValue = $encoder->decode($encodedValue);
+
+        $this->assertSame($accessToken, $decodedValue->getAccessToken());
+        $this->assertSame($userId, $decodedValue->getUserId());
+    }
+
+    public function testParseInvalidValue()
+    {
+        $invalidValue = 'invalid:value';
+
+        $encoder = new RefreshTokenValueEncoder();
+        $decodedValue = $encoder->decode($invalidValue);
+
+        $this->assertNull($decodedValue);
+    }
+}

--- a/tests/Repository/RefreshTokenValueTest.php
+++ b/tests/Repository/RefreshTokenValueTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wearesho\Yii2\Authorization\Tests\Repository;
+
+use PHPUnit\Framework\TestCase;
+use Wearesho\Yii2\Authorization\Repository\RefreshTokenValue;
+
+class RefreshTokenValueTest extends TestCase
+{
+    public function testConstructorAndGetters()
+    {
+        $accessToken = 'sampleAccessToken';
+        $userId = 123;
+
+        $refreshToken = new RefreshTokenValue($accessToken, $userId);
+
+        $this->assertSame($accessToken, $refreshToken->getAccessToken());
+        $this->assertSame($userId, $refreshToken->getUserId());
+    }
+}

--- a/tests/RepositoryTest.php
+++ b/tests/RepositoryTest.php
@@ -19,7 +19,7 @@ class RepositoryTest extends TestCase
         $repository = new Authorization\Repository([
             'redis' => $this->createMock(redis\Connection::class),
             'config' => $this->createMock(Authorization\Config::class),
-            'factory' => new UuidFactory(new FeatureSet),
+            'factory' => new UuidFactory(new FeatureSet()),
             'refreshEncoder' => $this->createMock(
                 Authorization\Repository\RefreshTokenValueEncoder::class
             ),
@@ -33,7 +33,7 @@ class RepositoryTest extends TestCase
         $repository = new Authorization\Repository([
             'redis' => $redis = $this->createMock(redis\Connection::class),
             'config' => $this->createMock(Authorization\Config::class),
-            'factory' => new UuidFactory(new FeatureSet),
+            'factory' => new UuidFactory(new FeatureSet()),
             'refreshEncoder' => $this->createMock(
                 Authorization\Repository\RefreshTokenValueEncoder::class
             ),
@@ -63,7 +63,7 @@ class RepositoryTest extends TestCase
         $repository = new Authorization\Repository([
             'redis' => $redis = $this->createMock(redis\Connection::class),
             'config' => $this->createMock(Authorization\Config::class),
-            'factory' => new UuidFactory(new FeatureSet),
+            'factory' => new UuidFactory(new FeatureSet()),
             'refreshEncoder' => $this->createMock(
                 Authorization\Repository\RefreshTokenValueEncoder::class
             ),
@@ -92,7 +92,7 @@ class RepositoryTest extends TestCase
         $repository = new Authorization\Repository([
             'redis' => $redis = $this->createMock(redis\Connection::class),
             'config' => $this->createMock(Authorization\Config::class),
-            'factory' => new UuidFactory(new FeatureSet),
+            'factory' => new UuidFactory(new FeatureSet()),
             'refreshEncoder' => $this->createMock(
                 Authorization\Repository\RefreshTokenValueEncoder::class
             ),
@@ -122,7 +122,7 @@ class RepositoryTest extends TestCase
         $repository = new Authorization\Repository([
             'redis' => $redis = $this->createMock(redis\Connection::class),
             'config' => $this->createMock(Authorization\Config::class),
-            'factory' => new UuidFactory(new FeatureSet),
+            'factory' => new UuidFactory(new FeatureSet()),
             'refreshEncoder' => $this->createMock(
                 Authorization\Repository\RefreshTokenValueEncoder::class
             ),
@@ -151,7 +151,7 @@ class RepositoryTest extends TestCase
         $repository = new Authorization\Repository([
             'redis' => $redis = $this->createMock(redis\Connection::class),
             'config' => $this->createMock(Authorization\Config::class),
-            'factory' => new UuidFactory(new FeatureSet),
+            'factory' => new UuidFactory(new FeatureSet()),
             'refreshEncoder' => $this->createMock(
                 Authorization\Repository\RefreshTokenValueEncoder::class
             ),
@@ -179,7 +179,7 @@ class RepositoryTest extends TestCase
         $repository = new Authorization\Repository([
             'redis' => $this->createMock(redis\Connection::class),
             'config' => $this->createMock(Authorization\Config::class),
-            'factory' => new UuidFactory(new FeatureSet),
+            'factory' => new UuidFactory(new FeatureSet()),
             'refreshEncoder' => $this->createMock(
                 Authorization\Repository\RefreshTokenValueEncoder::class
             ),
@@ -194,7 +194,7 @@ class RepositoryTest extends TestCase
         $repository = new Authorization\Repository([
             'redis' => $redis = $this->createMock(redis\Connection::class),
             'config' => $this->createMock(Authorization\Config::class),
-            'factory' => new UuidFactory(new FeatureSet),
+            'factory' => new UuidFactory(new FeatureSet()),
             'refreshEncoder' => $this->createMock(
                 Authorization\Repository\RefreshTokenValueEncoder::class
             ),
@@ -223,7 +223,7 @@ class RepositoryTest extends TestCase
         $repository = new Authorization\Repository([
             'redis' => $redis = $this->createMock(redis\Connection::class),
             'config' => $this->createMock(Authorization\Config::class),
-            'factory' => new UuidFactory(new FeatureSet),
+            'factory' => new UuidFactory(new FeatureSet()),
             'refreshEncoder' => $refreshEncoder = $this->createMock(
                 Authorization\Repository\RefreshTokenValueEncoder::class
             ),
@@ -270,7 +270,7 @@ class RepositoryTest extends TestCase
         $repository = new Authorization\Repository([
             'redis' => $redis = $this->createMock(redis\Connection::class),
             'config' => $this->createMock(Authorization\Config::class),
-            'factory' => new UuidFactory(new FeatureSet),
+            'factory' => new UuidFactory(new FeatureSet()),
             'refreshEncoder' => $refreshEncoder = $this->createMock(
                 Authorization\Repository\RefreshTokenValueEncoder::class
             ),


### PR DESCRIPTION
The RefreshToken saving mechanism has been changed so that the tuple of access token and uuid is saved in the storage instead of the access token value (see RefreshTokenValueEncoder).
This way, when access keys are deleted, it will be possible to return the userId even if the access token is no longer available. As a consequence, it is possible to update the refresh/access pair when the access token is already out of date.