### PR TITLE
Add RefreshTokenStorage with default redis implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,19 @@ return [
                 'expireInterval' => 'PT30M', // 30 minutes
                 'refreshExpireInterval' => 'PT90M', // 90 minutes
             ],
+            // optional: you can configure refresh token storage
         ],
     ],
 ];
 
 ```
+
+For refresh token storage configuration you need to pass definition 
+of [RefreshTokenStorage](./src/Repository/RefreshTokenStorage.php) implementation.
+
+Available implementation:
+- [wearesho-team/yii2-authorization-refresh-storage-db](https://github.com/wearesho-team/yii2-authorization-refresh-storage-db)
+for storing refresh token using SQL database.
 
 ### HasToken
 To implement part of yii`s web\Identity interface you should use

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -11,6 +11,11 @@ class Bootstrap extends base\BaseObject implements base\BootstrapInterface
     /** @var string|array|ConfigInterface */
     public $config;
 
+    /** @var string|array|Repository\RefreshTokenStorage */
+    public $refreshTokenStorage = [
+        'class' => Repository\RefreshTokenStorageRedis::class,
+    ];
+
     /**
      * @throws base\InvalidConfigException
      */
@@ -20,6 +25,9 @@ class Bootstrap extends base\BaseObject implements base\BootstrapInterface
         if (is_null($this->config)) {
             throw new base\InvalidConfigException("Config definition must be set.");
         }
+        if (is_null($this->refreshTokenStorage)) {
+            throw new base\InvalidConfigException("RefreshTokenStorage definition must be set.");
+        }
     }
 
     public function bootstrap($app): void
@@ -27,6 +35,10 @@ class Bootstrap extends base\BaseObject implements base\BootstrapInterface
         \Yii::$container->set(
             ConfigInterface::class,
             $this->config
+        );
+        \Yii::$container->set(
+            Repository\RefreshTokenStorage::class,
+            $this->refreshTokenStorage
         );
     }
 }

--- a/src/Repository/RefreshTokenStorage.php
+++ b/src/Repository/RefreshTokenStorage.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wearesho\Yii2\Authorization\Repository;
+
+use Carbon\Carbon;
+
+/**
+ * Saving refresh token is placed in a separate interface to allow storing in other databases,
+ * to allow saving refresh tokens in cases when redis deleted data (for example, in case of reboot).
+ */
+interface RefreshTokenStorage
+{
+    public function push(string $key, string $value, Carbon $expireAt): void;
+
+    public function pull(string $key): ?string;
+
+    public function delete(string $key): void;
+
+    public function clean(): void;
+}

--- a/src/Repository/RefreshTokenStorageRedis.php
+++ b/src/Repository/RefreshTokenStorageRedis.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Wearesho\Yii2\Authorization\Repository;
+
+use Carbon\Carbon;
+use yii\redis;
+use yii\base;
+use yii\di;
+
+class RefreshTokenStorageRedis extends base\BaseObject implements RefreshTokenStorage
+{
+    /** @var string|array|redis\Connection */
+    public $redis = 'redis';
+
+    public function init(): void
+    {
+        parent::init();
+        $this->redis = di\Instance::ensure($this->redis, redis\Connection::class);
+    }
+
+    public function push(string $key, string $value, Carbon $expireAt): void
+    {
+        $expireRefresh = $expireAt->diffInSeconds();
+        $this->redis->setex(
+            $key,
+            $expireRefresh,
+            $value
+        );
+    }
+
+    public function pull(string $key): ?string
+    {
+        return $this->redis->get($key);
+    }
+
+    public function delete(string $key): void
+    {
+        $this->redis->del($key);
+    }
+
+    public function clean(): void
+    {
+        // redis automatically expiring refresh tokens
+        return;
+    }
+}

--- a/tests/BootstrapTest.php
+++ b/tests/BootstrapTest.php
@@ -18,23 +18,56 @@ class BootstrapTest extends TestCase
         new Authorization\Bootstrap();
     }
 
+    public function testMissingRefreshTokenStorageDefinition(): void
+    {
+        $this->expectException(base\InvalidConfigException::class);
+        $this->expectExceptionMessage('RefreshTokenStorage definition must be set.');
+        new Authorization\Bootstrap([
+            'config' => [
+                'class' => Authorization\EnvironmentConfig::class,
+            ],
+            'refreshTokenStorage' => null,
+        ]);
+    }
+
     public function testSettingDefinitionOnContainer(): void
     {
         $container = $this->createMock(di\Container::class);
         \Yii::$container = $container;
 
         $configDefinition = $this->createMock(Authorization\Config::class);
+        $refreshTokenStorageDefinition = [
+            'class' => Authorization\Repository\RefreshTokenStorageRedis::class,
+            'redis' => 'redis2',
+        ];
 
         $container
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('set')
-            ->with(
-                Authorization\ConfigInterface::class,
-                $configDefinition
+            ->willReturn(
+                function (
+                    string $class,
+                    $definition
+                ) use (
+                    $configDefinition,
+                    $refreshTokenStorageDefinition
+                ): void {
+                    switch ($class) {
+                        case Authorization\ConfigInterface::class:
+                            $this->assertEquals($definition, $configDefinition);
+                            break;
+                        case Authorization\Repository\RefreshTokenStorage::class:
+                            $this->assertEquals($definition, $refreshTokenStorageDefinition);
+                            break;
+                        default:
+                            $this->fail("Unexpected class configured: " . $class);
+                    }
+                },
             );
 
         $bootstrap = new Authorization\Bootstrap([
             'config' => $configDefinition,
+            'refreshTokenStorage' => $refreshTokenStorageDefinition,
         ]);
         $bootstrap->bootstrap($this->createMock(base\Application::class));
     }


### PR DESCRIPTION
 Saving refresh token is placed in a separate interface to allow storing in other databases,
 to allow saving refresh tokens in cases when redis deleted data (for example, in case of reboot).